### PR TITLE
Use gradle to manage build and dependencies

### DIFF
--- a/kidneyMatching/build.gradle
+++ b/kidneyMatching/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'maven'
 
 group = 'kidneyMatching'
 version = '1.0-SNAPSHOT'
@@ -33,7 +32,9 @@ tasks.withType(Test) {
     systemProperty 'java.library.path', '/usr/local/CPLEX_Studio/cplex/bin/x86-64_osx'
 }
 dependencies {
-    compile files('lib/lib64/cplex125.jar')
+    // link to cplex jar:
+    // ln -s $CPLEX_HOME/cplex/lib/cplex.jar lib/lib64/cplex127.jar
+    compile files('lib/lib64/cplex127.jar')
     compile group: 'com.google.guava', name: 'guava', version:'16.0'
     compile group: 'colt', name: 'colt', version:'1.2.0'
     compile group: 'org.ggf.drmaa', name: 'drmaa', version:'1.0'

--- a/kidneyMatching/build.gradle
+++ b/kidneyMatching/build.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'kidneyMatching'
+version = '1.0-SNAPSHOT'
+
+description = """"""
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src', 'genSrc']
+        }
+    }
+    test {
+        java {
+            srcDir 'test'
+        }
+    }
+}
+
+repositories {
+     maven { url "http://repo1.maven.org/maven2/" }
+     // repo for drmaa
+     maven { url "https://dev-iesl.cs.umass.edu/nexus/content/repositories/releases" }
+}
+tasks.withType(Test) {
+    // equivalent to `-Djava.library.path=...`
+    // change it according to your cplex install
+    systemProperty 'java.library.path', '/usr/local/CPLEX_Studio/cplex/bin/x86-64_osx'
+}
+dependencies {
+    compile files('lib/lib64/cplex125.jar')
+    compile group: 'com.google.guava', name: 'guava', version:'16.0'
+    compile group: 'colt', name: 'colt', version:'1.2.0'
+    compile group: 'org.ggf.drmaa', name: 'drmaa', version:'1.0'
+    compile group: 'net.sf.jung', name: 'jung-algorithms', version:'2.0.1'
+    compile group: 'net.sf.jung', name: 'jung-graph-impl', version:'2.0.1'
+    compile group: 'net.sf.jung', name: 'jung-visualization', version:'2.0.1'
+    compile group: 'org.jfree', name: 'jfreechart', version:'1.0.19'
+    compile group: 'joda-time', name: 'joda-time', version:'2.3'
+    compile group: 'com.google.protobuf', name: 'protobuf-java', version:'2.5.0'
+    compile group: 'net.sourceforge.collections', name: 'collections-generic', version:'4.01'
+    compile group: 'commons-io', name: 'commons-io', version:'2.4'
+    compile group: 'org.apache.commons', name: 'commons-csv', version:'1.0'
+    compile group: 'org.apache.commons', name: 'commons-math3', version:'3.1.1'
+    compile group: 'com.thetransactioncompany', name: 'jsonrpc2-server', version:'1.11'
+    compile group: 'com.beust', name: 'jcommander', version:'1.72'
+    compile group: 'com.lowagie', name: 'itext', version:'2.1.5'
+    compile group: 'org.eclipse.jetty', name: 'jetty-server', version:'7.5.0.v20110901'
+    testCompile group: 'junit', name: 'junit', version:'4.12'
+}

--- a/kidneyMatching/src/data/ProblemDataWriter.java
+++ b/kidneyMatching/src/data/ProblemDataWriter.java
@@ -105,7 +105,7 @@ public class ProblemDataWriter {
 			for(int i = 0; i < format.getNumColumns(); i++){
 				firstRow[i]=format.getColumnNames().get(columnNameToPositionReversed.get(i));
 			}
-			printer.println(firstRow);
+			printer.printRecord(firstRow);
 			for(Donor donor: data.getAltruisticDonors().keySet()){
 				printDonor(donor,data.getAltruisticDonors().get(donor));
 			}
@@ -118,7 +118,7 @@ public class ProblemDataWriter {
 			for(Receiver receiver: data.getChips().keySet()){
 				printReceiver(receiver,data.getChips().get(receiver));
 			}
-			printer.println("--XXMY_o_YMXX--");
+			printer.printRecord("--XXMY_o_YMXX--");
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -133,7 +133,7 @@ public class ProblemDataWriter {
 			row[position] = value;
 		}
 		try {
-			this.printer.println(row);
+			this.printer.printRecord(row);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -253,7 +253,7 @@ public class ProblemDataWriter {
 			row[position] = value;
 		}
 		try {
-			this.printer.println(row);
+			this.printer.printRecord(row);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/kidneyMatching/src/exchangeGraph/CycleChainPackingSubtourElimination.java
+++ b/kidneyMatching/src/exchangeGraph/CycleChainPackingSubtourElimination.java
@@ -218,7 +218,7 @@ public class CycleChainPackingSubtourElimination<V, E> extends
         violatedConstraints = userCutGen.fullUserCut();
       }
       for (IloRange constraint : violatedConstraints) {
-        this.add(constraint);
+        this.addLocal(constraint);
       }
     }
   }

--- a/kidneyMatching/src/exchangeGraph/minWaitingTime/MinWaitingTimeKepSolver.java
+++ b/kidneyMatching/src/exchangeGraph/minWaitingTime/MinWaitingTimeKepSolver.java
@@ -478,15 +478,15 @@ public class MinWaitingTimeKepSolver<V, E> {
       }
       if (!violatedConstraints.isEmpty()) {
         for (IloRange constraint : violatedConstraints) {
-          this.add(constraint);
+          this.addLocal(constraint);
         }
       } else if (addConsistencyConstraintsLazily) {
         ImmutableTable<V, V, Double> precVarVals = getPrecedenceVariableValues(this);
         for (List<V> constraint : precedenceConsistencyConstraintGenerator
             .checkFractionalSolution(kepPolytope.getEdgeVariables()
                 .getNonZeroVariableValues(this), precVarVals)) {
-          this.add(createPrecedenceConsistencyConstraint(constraint.get(0),
-              constraint.get(1), constraint.get(2)));
+          this.addLocal(createPrecedenceConsistencyConstraint(constraint.get(0),
+                  constraint.get(1), constraint.get(2)));
         }
         long totalFractionalCuts = precedenceConsistencyConstraintGenerator
             .getFractionalCutsAdded();

--- a/kidneyMatching/src/exchangeGraph/stochasticOpt/TwoStageEdgeFailureSolver.java
+++ b/kidneyMatching/src/exchangeGraph/stochasticOpt/TwoStageEdgeFailureSolver.java
@@ -194,7 +194,7 @@ public class TwoStageEdgeFailureSolver<V,E> {
 				}
 			}
 			for(IloRange constraint: violatedConstraints){
-				this.add(constraint);
+				this.addLocal(constraint);
 			}
 		}		
 	}

--- a/kidneyMatching/src/inputOutput/ExchangeUnitReportGenerator.java
+++ b/kidneyMatching/src/inputOutput/ExchangeUnitReportGenerator.java
@@ -194,7 +194,7 @@ public class ExchangeUnitReportGenerator {
 				if(col != this.numColumns){
 					throw new RuntimeException();
 				}
-				printer.println(firstRow);
+				printer.printRecord(firstRow);
 			}
 			for(ExchangeUnit unit: this.exchangeUnits){
 				String[] nextRow = new String[this.numColumns];			
@@ -210,7 +210,7 @@ public class ExchangeUnitReportGenerator {
 						//nextRow[col++] = this.exchangeUnitAttributeOut.getDonorAttributes().get(columnName).get(i).getValueFormatted(unit);
 					}				
 				}
-				printer.println(nextRow);
+				printer.printRecord(nextRow);
 			}
 			printer.flush();
 			writer.close();

--- a/kidneyMatching/src/inputOutput/core/CsvFormatUtil.java
+++ b/kidneyMatching/src/inputOutput/core/CsvFormatUtil.java
@@ -321,10 +321,10 @@ public class CsvFormatUtil {
   public static CsvFormat<List<? extends Person>> personListNameFormat = makeListFormat(
       idFormat, "|");
 
-  public static CSVFormat pgfPlotFileFormat = CSVFormat.EXCEL.withEncapsulator(
+  public static CSVFormat pgfPlotFileFormat = CSVFormat.EXCEL.withQuote(
       ' ').withDelimiter(' ');
   public static CSVFormat pgfPlotTableFormat = CSVFormat.EXCEL
-      .withEncapsulator(' ');
+      .withQuote(' ');
 
   public static CsvFormat<StatisticalSummary> meanFormat = new CsvFormat<StatisticalSummary>() {
     @Override

--- a/kidneyMatching/src/inputOutput/core/Report.java
+++ b/kidneyMatching/src/inputOutput/core/Report.java
@@ -42,7 +42,7 @@ public class Report<V> {
       BufferedWriter writer = new BufferedWriter(new FileWriter(fileName));
       CSVPrinter printer = new CSVPrinter(writer, format);
       if (this.useTitles) {
-        printer.println(this.titles.toArray(new String[titles.size()]));
+        printer.printRecord(this.titles.toArray(new String[titles.size()]));
       }
       for (V entry : entries) {
         if (predicate.apply(entry)) {
@@ -50,7 +50,7 @@ public class Report<V> {
           for (AttributeConverter<V> converter : converters) {
             nextLine.add(converter.apply(entry));
           }
-          printer.println(nextLine.toArray(new String[this.converters.size()]));
+          printer.printRecord(nextLine.toArray(new String[this.converters.size()]));
         }
       }
       printer.flush();

--- a/kidneyMatching/src/multiPeriodAnalysis/DrmaaExperimentRunner.java
+++ b/kidneyMatching/src/multiPeriodAnalysis/DrmaaExperimentRunner.java
@@ -200,10 +200,14 @@ public class DrmaaExperimentRunner<V, E, T extends Comparable<T>> implements
       try {
         jt.setErrorPath(":" + getStdErrorNameForId(job.getOutFileId()));
         jt.setOutputPath(":" + getStdOutNameForId(job.getOutFileId()));
-        List<String> args = Lists.newArrayList("-Djava.library.path="
-            + drmaaLocation + ":" + cplexLocation, "-jar", programLocation,
-            "-m", "worker", "-t", Integer.toString(environment.getThreads()),
-            "-s", jobFileName, "-o", getSimResultNameForId(job.getOutFileId()));
+        String[] args = {
+          "-Djava.library.path=" + drmaaLocation + ":" + cplexLocation,
+          "-jar", programLocation,
+          "-m", "worker",
+          "-t", Integer.toString(environment.getThreads()),
+          "-s", jobFileName,
+          "-o", getSimResultNameForId(job.getOutFileId())
+        };
         jt.setArgs(args);
         String id = session.runJob(jt);
         ans.add(id);


### PR DESCRIPTION
This adds gradle support to the project, for reproducible build and better dependency
management.

Though this brought in a few incompatible issues. E.g. `CSVPrinter.println` is not available in the (even the oldest) commons-csv(http://mvnrepository.com/artifact/org.apache.commons/commons-csv). It has been replaced with `CSVPrinter.printRecord` . Also replaced `withEncapsulator` with `withQuote`.

And CPLEX 12.7 no longer support `UserCutCallback.add(IloRange)` method, thus was replaced by `addLocal`. (Not sure if they are interchangeable, but I have been able to pass all tests)

@rma350 I have tinkered only the surface part of the project, and have not dived much in yet. So I am not sure if this is a valuable change, let me know what do you think. Thanks!

